### PR TITLE
Add custom select field answers to user export

### DIFF
--- a/services/export/src/utils/stream-results.js
+++ b/services/export/src/utils/stream-results.js
@@ -44,7 +44,6 @@ const executor = async (args) => {
 
     const customSelectAnswers = customSelectFields.reduce((o, customSelect) => {
       let rowLabel = `Custom: ${customSelect.name}`;
-      const { multiple } = customSelect;
       if (!customSelect.active) rowLabel = `${rowLabel} [inactive]`;
       const userAnswers = getAsArray(node, 'customSelectFieldAnswers');
       const fieldAnswer = userAnswers.find(answer => `${answer._id}` === `${customSelect._id}`);
@@ -53,9 +52,7 @@ const executor = async (args) => {
           .map(value => customSelect.options.find(option => `${option._id}` === `${value}`).label)
           .filter(option => option)
         : [];
-      console.log(answeredOptions);
-
-      return { ...o, [rowLabel]: multiple ? answeredOptions.join('|') : (answeredOptions[0] || '') };
+      return { ...o, [rowLabel]: customSelect.multiple ? answeredOptions.join('|') : (answeredOptions[0] || '') };
     }, {});
 
     return { ...row, ...customSelectAnswers, ...answers };

--- a/services/export/src/utils/stream-results.js
+++ b/services/export/src/utils/stream-results.js
@@ -1,5 +1,7 @@
 const { getAsArray, getAsObject } = require('@base-cms/object-path');
 
+const { isArray } = Array;
+
 /**
  * Pipes results to the passed input stream
  * @param {object} args The function args
@@ -17,6 +19,7 @@ const executor = async (args) => {
     limit = 500,
     fields,
     regionalConsentPolicies,
+    customSelectFields,
     stream,
   } = args;
   const pagination = getAsObject(params, 'pagination');
@@ -38,7 +41,24 @@ const executor = async (args) => {
       const given = answer ? answer.given : false;
       return { ...o, [`Consent: ${policy.name}`]: given };
     }, {});
-    return { ...row, ...answers };
+
+    const customSelectAnswers = customSelectFields.reduce((o, customSelect) => {
+      let rowLabel = `Custom: ${customSelect.name}`;
+      const { multiple } = customSelect;
+      if (!customSelect.active) rowLabel = `${rowLabel} [inactive]`;
+      const userAnswers = getAsArray(node, 'customSelectFieldAnswers');
+      const fieldAnswer = userAnswers.find(answer => `${answer._id}` === `${customSelect._id}`);
+      const answeredOptions = fieldAnswer && isArray(fieldAnswer.values)
+        ? fieldAnswer.values
+          .map(value => customSelect.options.find(option => `${option._id}` === `${value}`).label)
+          .filter(option => option)
+        : [];
+      console.log(answeredOptions);
+
+      return { ...o, [rowLabel]: multiple ? answeredOptions.join('|') : (answeredOptions[0] || '') };
+    }, {});
+
+    return { ...row, ...customSelectAnswers, ...answers };
   });
   stream.push(JSON.stringify(nodes));
   const { hasNextPage, endCursor } = getAsObject(data, 'pageInfo');

--- a/services/export/src/utils/stream-results.js
+++ b/services/export/src/utils/stream-results.js
@@ -49,8 +49,9 @@ const executor = async (args) => {
       const fieldAnswer = userAnswers.find(answer => `${answer._id}` === `${customSelect._id}`);
       const answeredOptions = fieldAnswer && isArray(fieldAnswer.values)
         ? fieldAnswer.values
-          .map(value => customSelect.options.find(option => `${option._id}` === `${value}`).label)
+          .map(value => customSelect.options.find(option => `${option._id}` === `${value}`))
           .filter(option => option)
+          .map(option => option.label)
         : [];
       return { ...o, [rowLabel]: customSelect.multiple ? answeredOptions.join('|') : (answeredOptions[0] || '') };
     }, {});


### PR DESCRIPTION
Exports custom select field answers for each user within the CSV export. If no custom fields are defined, no answers will be included in the export. Both active and inactive questions will be included, but inactive questions will be flagged as such. Answers for multi-select questions will be pipe-separated.

Ref base-cms/id-me#80